### PR TITLE
Ignore eggs when measuring coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -15,6 +15,8 @@ exclude_lines =
 omit =
     */python?.?/*
     */site-packages/*
+    */eggs/*
+    */.eggs/*
     *tests/*
     */travis_pypi_setup.py
     */versioneer.py


### PR DESCRIPTION
If dependencies are installed into a local `eggs` or `.eggs` directory, they can be picked by `coverage` when measure the test coverage. To avoid this, we exclude these directories in `.coveragerc`.