### PR TITLE
Require `mock` for CI

### DIFF
--- a/environment_ci.yml
+++ b/environment_ci.yml
@@ -12,3 +12,4 @@ dependencies:
   # Requirements
   - matplotlib==1.5.3
   - npctypes==0.0.2
+  - mock==2.0.0


### PR DESCRIPTION
Even though we only need this for Python 2, go ahead and install it in all cases. Otherwise it will get installed in a local `.eggs` directory and we won't have any control over the version used.