### PR TITLE
Fix intensity scale selection bug

### DIFF
--- a/mplview/core.py
+++ b/mplview/core.py
@@ -140,8 +140,13 @@ class MatplotlibViewer(matplotlib.figure.Figure):
                 vmax         the max value selected
         """
         if vmin != vmax:
-            self.svmin = (self.svmax - self.svmin) * vmin + self.svmin
-            self.svmax = (self.svmax - self.svmin) * vmax + self.svmin
+            svdiff = self.svmax - self.svmin
+
+            svmin = svdiff * vmin + self.svmin
+            svmax = svdiff * vmax + self.svmin
+
+            self.svmin = svmin
+            self.svmax = svmax
         else:
             self.svmin = self.vmin
             self.svmax = self.vmax


### PR DESCRIPTION
It appears that the code for intensity scale selection had a bug where it used the updated scale minimum when computing the update to the scale maximum. The result being we could end up with a scale maximum larger than it should be if an adjustment was made to the scale minimum. We fix this by using temporaries to store the results of the update minimum and maximum before actually storing the updated scale values. As we don't use the temporaries in our computation, we won't re-encounter the same bug.