### PR TITLE
Drop mock from test requirements

### DIFF
--- a/environment_ci.yml
+++ b/environment_ci.yml
@@ -12,4 +12,3 @@ dependencies:
   # Requirements
   - matplotlib==1.5.3
   - npctypes==0.0.2
-  - mock==2.0.0

--- a/setup.py
+++ b/setup.py
@@ -20,8 +20,6 @@ requirements = [
 ]
 
 test_requirements = []
-if sys.version_info < (3,):
-    test_requirements.append("mock")
 
 
 setup(


### PR DESCRIPTION
After writing the tests, it seems we are able to get them to work without resorting to `mock`. So drop the dependency as we are not using `mock` for anything else.