### PR TITLE
Bust GitHub's badge cache

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,7 @@ mplview
         :target: https://pypi.python.org/pypi/mplview
         :alt: PyPI
 
-.. image:: https://anaconda.org/conda-forge/mplview/badges/version.svg
+.. image:: https://anaconda.org/conda-forge/mplview/badges/version.svg?bust=1
         :target: https://anaconda.org/conda-forge/mplview
         :alt: conda-forge
 
@@ -19,7 +19,7 @@ mplview
         :target: https://mplview.readthedocs.io/en/latest/?badge=latest
         :alt: Read the Docs
 
-.. image:: https://coveralls.io/repos/github/jakirkham/mplview/badge.svg
+.. image:: https://coveralls.io/repos/github/jakirkham/mplview/badge.svg?bust=1
         :target: https://coveralls.io/github/jakirkham/mplview
         :alt: Coveralls
 


### PR DESCRIPTION
Appears that GitHub's cache is stale and nothing else is working. This attempts to fix the issue by changing the URL. Here we pass unused arguments to the outdated badges. While the arguments do nothing for the services, this does change the URL, which forces camo, the caching service, to retrieve the badges as these URLs are not already cached. Also it should allow camo to drop the existing badges from cache during garbage collection. That way we can return to the original URLs and get new badges into cache.