### PR TITLE
Coerce array

### DIFF
--- a/mplview/core.py
+++ b/mplview/core.py
@@ -2,6 +2,8 @@ __author__ = "John Kirkham <kirkhamj@janelia.hhmi.org>"
 __date__ = "$Nov 01, 2016 9:19$"
 
 
+import numpy as np
+
 import matplotlib as mpl
 import matplotlib.figure
 import matplotlib.colors
@@ -126,6 +128,8 @@ class MatplotlibViewer(matplotlib.figure.Figure):
         cur_img = cur_img[...]
 
         cur_img = cur_img.astype(float)
+
+        cur_img = np.asarray(cur_img)
 
         return(cur_img)
 

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ with open("HISTORY.rst") as history_file:
 requirements = [
     "matplotlib",
     "npctypes",
+    "numpy",
 ]
 
 test_requirements = []


### PR DESCRIPTION
When getting an image frame, make sure it is a NumPy array. This is helpful when trying to display a Dask Array for instance. With Dask Arrays, this will force a computation to occur to get the frame requested. In regular cases of NumPy arrays, this ends up being a no-op.