### PR TITLE
Fix a bare `except` clause by requiring `Exception`

### DIFF
--- a/mplview/core.py
+++ b/mplview/core.py
@@ -190,7 +190,7 @@ class MatplotlibViewer(matplotlib.figure.Figure):
             z = self.get_image()[yi, xi]
 
             return 'x=%1.4f, y=%1.4f, z=%1.4f'%(x, y, z)
-        except:
+        except Exception:
             return 'x=%1.4f, y=%1.4f'%(x, y)
 
 


### PR DESCRIPTION
Fixes https://github.com/jakirkham/mplview/issues/11

There is no reason we need to catch an arbitrary exception here. We should be getting a NumPy array, which we will need to index. The index could be out of bounds, which would be an `IndexError`. There is a remote possibility that the coordinates provides are not `float` for some reason. So coercing them to `int`s may fail, which would be a `ValueError`. To keep this general, just make the bare `except` catch any `Exception`, which should handle both of these cases.