### PR TITLE
Reuse current image

### DIFF
--- a/mplview/core.py
+++ b/mplview/core.py
@@ -63,6 +63,8 @@ class MatplotlibViewer(matplotlib.figure.Figure):
             )
 
         self.neuron_images = new_neuron_images
+        self._cur_img_time = None
+        self._cur_img = None
         self.cmap = cmap
         self.vmin = vmin
         self.vmax = vmax
@@ -123,16 +125,21 @@ class MatplotlibViewer(matplotlib.figure.Figure):
         else:
             i = 0
 
-        cur_img = self.neuron_images
-        if (len(self.neuron_images.shape) == 3):
-            cur_img = cur_img[i]
-        else:
-            cur_img = cur_img[...]
+        if i != self._cur_img_time:
+            cur_image = self._cur_img
 
-        cur_img = numpy.asarray(cur_img[...])
-        cur_img = cur_img.astype(float)
+            if (len(self.neuron_images.shape) == 3):
+                cur_img = self.neuron_images[i]
+            else:
+                cur_img = self.neuron_images[...]
 
-        return(cur_img)
+            cur_img = numpy.asarray(cur_img[...])
+            cur_img = cur_img.astype(float)
+
+            self._cur_img_time = i
+            self._cur_img = cur_img
+
+        return(self._cur_img)
 
 
     def color_range_update(self, vmin, vmax):

--- a/mplview/core.py
+++ b/mplview/core.py
@@ -125,11 +125,9 @@ class MatplotlibViewer(matplotlib.figure.Figure):
         else:
             cur_img = cur_img[...]
 
-        cur_img = cur_img[...]
+        cur_img = numpy.asarray(cur_img[...])
 
         cur_img = cur_img.astype(float)
-
-        cur_img = numpy.asarray(cur_img)
 
         return(cur_img)
 

--- a/mplview/core.py
+++ b/mplview/core.py
@@ -126,7 +126,6 @@ class MatplotlibViewer(matplotlib.figure.Figure):
             cur_img = cur_img[...]
 
         cur_img = numpy.asarray(cur_img[...])
-
         cur_img = cur_img.astype(float)
 
         return(cur_img)

--- a/mplview/core.py
+++ b/mplview/core.py
@@ -118,9 +118,11 @@ class MatplotlibViewer(matplotlib.figure.Figure):
                 numpy.ndarray:      the current image.
         """
 
-        cur_img = self.neuron_images
         if (len(self.neuron_images.shape) == 3):
             i = self.time_nav.stime.val if i is None else i
+
+        cur_img = self.neuron_images
+        if (len(self.neuron_images.shape) == 3):
             cur_img = cur_img[i]
         else:
             cur_img = cur_img[...]

--- a/mplview/core.py
+++ b/mplview/core.py
@@ -120,6 +120,8 @@ class MatplotlibViewer(matplotlib.figure.Figure):
 
         if (len(self.neuron_images.shape) == 3):
             i = self.time_nav.stime.val if i is None else i
+        else:
+            i = 0
 
         cur_img = self.neuron_images
         if (len(self.neuron_images.shape) == 3):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -52,6 +52,28 @@ class TestMatplotlibViewer(unittest.TestCase):
         cur_img = self.mplv.get_image(-1)
         self.assertTrue(numpy.array_equal(img[-1], cur_img))
 
+    def test_image_stack_retry(self):
+        img = numpy.arange(60.0).reshape(5,3,4)
+        self.mplv.set_images(img)
+
+        cur_img = self.mplv.get_image()
+        self.assertTrue(numpy.array_equal(img[0], cur_img))
+
+        cur_img = self.mplv.get_image()
+        self.assertTrue(numpy.array_equal(img[0], cur_img))
+
+        cur_img = self.mplv.get_image(2)
+        self.assertTrue(numpy.array_equal(img[2], cur_img))
+
+        cur_img = self.mplv.get_image(2)
+        self.assertTrue(numpy.array_equal(img[2], cur_img))
+
+        cur_img = self.mplv.get_image(-1)
+        self.assertTrue(numpy.array_equal(img[-1], cur_img))
+
+        cur_img = self.mplv.get_image(-1)
+        self.assertTrue(numpy.array_equal(img[-1], cur_img))
+
     def test_init_too_big(self):
         img = numpy.arange(60.0).reshape(1,5,3,4)
         with self.assertRaises(ValueError) as e:


### PR DESCRIPTION
Tries to reuse the current image displayed in `get_image` calls. Should speed up operations like inspecting intensities at coordinates within a frame.