### PR TITLE
Require matplotlib <3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ with open("HISTORY.rst") as history_file:
     history = history_file.read()
 
 requirements = [
-    "matplotlib",
+    "matplotlib <3",
     "npctypes",
     "numpy",
 ]


### PR DESCRIPTION
As matplotlib 3 causes a fair amount of breakage that will require some time to investigate and fix, just require matplotlib 2 for now.

Note: Workaround for issue ( https://github.com/jakirkham/mplview/issues/32 ) and issue ( https://github.com/jakirkham/mplview/issues/30 ).